### PR TITLE
1.20.1: Fix head rotation issue with lerp between wading and swimming animations

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -11,5 +11,5 @@ dependencies {
     modApi "fuzs.forgeconfigapiport:forgeconfigapiport-common:$rootProject.fcap_version"
     modCompileOnly "me.shedaniel.cloth:cloth-config:$rootProject.cloth_config_version"
     modCompileOnly "maven.modrinth:origins:1.10.2+mc.1.20.1"
-    modCompileOnly "io.github.apace100:apoli-2.9.2-mc.1.20.1:2.9.2+mc.1.20.x"
+    modCompileOnly "io.github.apace100:apoli:2.9.2+mc.1.20.x"
 }

--- a/common/src/main/java/io/github/thatpreston/mermod/mixin/HumanoidModelMixin.java
+++ b/common/src/main/java/io/github/thatpreston/mermod/mixin/HumanoidModelMixin.java
@@ -45,6 +45,7 @@ public abstract class HumanoidModelMixin<T extends LivingEntity> extends Ageable
                     this.leftArm.zRot = Mth.lerp(left, this.leftArm.zRot, -z);
                 }
                 this.head.xRot = this.rotlerpRad(this.swimAmount, pitch * 0.017453292F, -Mth.PI / 3);
+                this.head.yRot = (float)Math.IEEEremainder(this.head.yRot, Mth.TWO_PI);
                 this.head.yRot *= Mth.lerp(this.swimAmount, 1, 0.5F);
                 this.hat.copyFrom(this.head);
                 info.cancel();

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     }
     modImplementation("com.terraformersmc:modmenu:$rootProject.modmenu_version")
     modImplementation "maven.modrinth:origins:1.10.2+mc.1.20.1"
-    modImplementation "io.github.apace100:apoli-2.9.2-mc.1.20.1:2.9.2+mc.1.20.x"
+    modImplementation "io.github.apace100:apoli:2.9.2+mc.1.20.x"
     common(project(path: ':common', configuration: 'namedElements')) { transitive = false }
     shadowBundle project(path: ':common', configuration: 'transformProductionFabric')
 }


### PR DESCRIPTION

https://github.com/user-attachments/assets/ac2cb548-6d4f-4151-80ba-3a8ab2578f32

Fixes https://github.com/ThatPreston/Mermod/issues/16

This glitch is on fabric 1.20.1 and forge 1.20.1. I could not recreate it on fabric 1.21.11. Attached is a recording of the bug on fabric 1.20.1 Singleplayer with no other mods installed except dependencies for Mermod.

Summary: When spawning in on a server with a misaligned head and body, or when rotating the camera quickly, the player's head will become any amount of full rotations misaligned with the body; this is only corrected when the player unwinds themselves by moving their camera aggressively in the correct direction.

Fix: Subtract the full rotations out of the player head's Y axis rotation before the lerp begins.